### PR TITLE
v1.7.3-hotfix

### DIFF
--- a/src/components/redbank/AssetTable/AssetTable.tsx
+++ b/src/components/redbank/AssetTable/AssetTable.tsx
@@ -100,8 +100,8 @@ export const AssetTable = ({ data, columns, type, disabled = false }: Props) => 
           if (row.depth === 1) {
             return (
               <React.Fragment key={`${row.id}_subrow`}>
-                <ActionsRow key={`${row.id}_actions`} row={table.getRow(row.id[0])} type={type} />
-                <MetricsRow key={`${row.id}_metrics`} row={table.getRow(row.id[0])} type={type} />
+                <ActionsRow key={`${row.original.id}_actions`} row={row} type={type} />
+                <MetricsRow key={`${row.original.id}_metrics`} row={row} type={type} />
               </React.Fragment>
             )
           }


### PR DESCRIPTION
### Bugfix
- `getRow` defaults back to the first row, if it doesn't find the id due to pagination. Fixed it by using the row itself.